### PR TITLE
Show rejected grants in admin panel

### DIFF
--- a/resources/scss/_vars-day.scss
+++ b/resources/scss/_vars-day.scss
@@ -11,3 +11,4 @@ $disabled: #eaeaea;
 $bgNotification: $purple;
 $textNotification: $white;
 $bgActiveRound: #86ff86;
+$bgDisabled: lightgray;

--- a/resources/scss/_vars-night.scss
+++ b/resources/scss/_vars-night.scss
@@ -11,3 +11,4 @@ $disabled: #353535;
 $bgNotification: $lightLilac;
 $textNotification: $black;
 $bgActiveRound: green;
+$bgDisabled: darkgray;

--- a/resources/scss/components/popUpGrant.scss
+++ b/resources/scss/components/popUpGrant.scss
@@ -121,7 +121,7 @@
 			line-height: 53px;
 			&:disabled {
 				pointer-events: none;
-				background-color: lightgray;
+				background-color: $bgDisabled;
 			}
 		}
 		&.add {
@@ -198,7 +198,7 @@
 				color: $purple;
 				overflow: hidden;
 				&:disabled {
-					background-color: lightgray;
+					background-color: $bgDisabled;
 				}
 			}
 

--- a/resources/scss/layouts/admin.scss
+++ b/resources/scss/layouts/admin.scss
@@ -17,14 +17,25 @@
 		h3 {
 			font-size: 20px;;
 		}
-		.reviewButtons {
+		.control-header {
 			display: flex;
-			margin-bottom: 10px;
+			align-items: end;
 			justify-content: space-between;
-			.btBasic {
-				&:disabled {
-					pointer-events: none;
-					background-color: lightgray;
+			margin-bottom: 10px;
+			.showRejected {
+				.input-group {
+					display: none;
+				}
+			}
+			.reviewButtons {
+				display: flex;
+				justify-content: space-between;
+
+				.btBasic {
+					&:disabled {
+						pointer-events: none;
+						background-color: $bgDisabled;
+					}
 				}
 			}
 		}
@@ -43,6 +54,20 @@
 		background: $bgCard;
 		padding: 19.86px 15px 18.58px;
 		max-height: 500px;
+		&.rejected {
+			background-color: $bgDisabled;
+		}
+		.rejected-annotation {
+			position: absolute;
+			bottom: 5px;
+			right: 5px;
+			font-size: smaller;
+			background: #a478f9;
+			border-radius: 92px;
+			padding: 1px 4px;
+			color: white;
+			font-weight: bold;
+		}
 		.data {
 			width: 100%;
 			display: flex;
@@ -102,6 +127,11 @@
 			&.loading {
 				opacity: 0.3;
 				pointer-events: none;
+			}
+			.input-group {
+				.help-block {
+					display: none;
+				}
 			}
 		}
 		&.remove {
@@ -383,7 +413,7 @@
 			height: 56px;
 			&:disabled {
 				pointer-events: none;
-				background-color: lightgray;
+				background-color: $bgDisabled;
 			}
 		}
 	}
@@ -696,7 +726,7 @@
 
 				.btBasic:disabled {
 					pointer-events: none;
-					background-color: lightgray;
+					background-color: $bgDisabled;
 				}
 			}
 		}
@@ -716,7 +746,7 @@
 				.btBasic {
 					&:disabled {
 						pointer-events: none;
-						background-color: lightgray;
+						background-color: $bgDisabled;
 					}
 				}
 			}

--- a/resources/scss/layouts/profileEdit.scss
+++ b/resources/scss/layouts/profileEdit.scss
@@ -392,7 +392,7 @@
 			letter-spacing: 1.87px;
 			&:disabled {
 				pointer-events: none;
-				background-color: lightgray;
+				background-color: $bgDisabled;
 			}
 		}
 	}

--- a/resources/scss/layouts/round.scss
+++ b/resources/scss/layouts/round.scss
@@ -48,7 +48,7 @@
 
 				&:disabled {
 					pointer-events: none;
-					background-color: lightgray;
+					background-color: $bgDisabled;
 				}
 			}
 		}
@@ -85,7 +85,7 @@
 
 			&:disabled {
 				pointer-events: none;
-				background-color: lightgray;
+				background-color: $bgDisabled;
 			}
 		}
 	}

--- a/resources/scss/layouts/send-support.scss
+++ b/resources/scss/layouts/send-support.scss
@@ -123,7 +123,7 @@
 			margin-bottom: 23.09px;
 			&:disabled {
 				pointer-events: none;
-				background-color: lightgray;
+				background-color: $bgDisabled;
 			}
 		}
 		margin-bottom: 50px;

--- a/src/streamtide/ui/admin/grant_approval_feed/events.cljs
+++ b/src/streamtide/ui/admin/grant_approval_feed/events.cljs
@@ -59,10 +59,12 @@
 (re-frame/reg-event-fx
   ::review-grant-success
   (fn [{:keys [db]} [_ args]]
-    (let [{:keys [:user/addresses :grant/status]} args]
+    (let [{:keys [:user/addresses :grant/status :on-success]} args]
+      (when on-success
+        (on-success))
       {:db (-> db
                (dissoc :reviewing-grants?)
-               (update :reviewed-grant? merge (reduce (fn [col address] (conj col {address status})) {} addresses)))
+               (update :reviewed-grant merge (reduce (fn [col address] (conj col {address status})) {} addresses)))
        :dispatch [::notification-events/show (str "Grants successfully " (if (= :grant.status/approved status) "approved" "rejected")  )]})))
 
 (re-frame/reg-event-fx

--- a/src/streamtide/ui/admin/grant_approval_feed/subs.cljs
+++ b/src/streamtide/ui/admin/grant_approval_feed/subs.cljs
@@ -8,6 +8,6 @@
     (get db :reviewing-grants?)))
 
   (re-frame/reg-sub
-    ::decision?
+    ::decision
     (fn [db [_ address]]
-    (get-in db [:reviewed-grant? address])))
+    (get-in db [:reviewed-grant address])))


### PR DESCRIPTION
Once a Grant has been rejected, it was not possible to re-evaluated. This PR enables an option to also show rejected grants so they can be approved.